### PR TITLE
Add service accounts to access postgres db users + other changes

### DIFF
--- a/argo.tf
+++ b/argo.tf
@@ -43,10 +43,6 @@ resource "helm_release" "argocd" {
   }
 }
 
-data "kubectl_path_documents" "application" {
-    pattern = "./argocd/application.yaml"
-}
-
 resource "kubectl_manifest" "argocd" {
   depends_on = [helm_release.argocd]
   count      = length(data.kubectl_path_documents.application.documents)

--- a/argocd/manifests/helium/active-device-oracle.yaml
+++ b/argocd/manifests/helium/active-device-oracle.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: active-device-oracle
     spec:
-      serviceAccountName: rds_active_device_oracle_user_access
+      serviceAccountName: rds-active-device-oracle-user-access
       containers:
         - name: active-device-oracle
           image: 177106435319.dkr.ecr.us-east-1.amazonaws.com/active-device-oracle:0.0.1

--- a/argocd/manifests/helium/active-device-oracle.yaml
+++ b/argocd/manifests/helium/active-device-oracle.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: active-device-oracle
     spec:
-      serviceAccountName: app
+      serviceAccountName: rds_active_device_oracle_user_access
       containers:
         - name: active-device-oracle
           image: 177106435319.dkr.ecr.us-east-1.amazonaws.com/active-device-oracle:0.0.1

--- a/argocd/manifests/helium/active-device-oracle.yaml
+++ b/argocd/manifests/helium/active-device-oracle.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: active-device-oracle
     spec:
+      serviceAccountName: app
       containers:
         - name: active-device-oracle
           image: 177106435319.dkr.ecr.us-east-1.amazonaws.com/active-device-oracle:0.0.1

--- a/argocd/manifests/helium/active-device-oracle.yaml
+++ b/argocd/manifests/helium/active-device-oracle.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: active-device-oracle
+        security-group: rds-access
     spec:
       serviceAccountName: rds-active-device-oracle-user-access
       containers:

--- a/argocd/manifests/helium/mobile-oracle.yaml
+++ b/argocd/manifests/helium/mobile-oracle.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: mobile-oracle
     spec:
-      serviceAccountName: app
+      serviceAccountName: rds_mobile_oracle_user_access
       containers:
         - name: mobile-oracle
           image: 177106435319.dkr.ecr.us-east-1.amazonaws.com/distributor-oracle:0.0.2

--- a/argocd/manifests/helium/mobile-oracle.yaml
+++ b/argocd/manifests/helium/mobile-oracle.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: mobile-oracle
     spec:
+      serviceAccountName: app
       containers:
         - name: mobile-oracle
           image: 177106435319.dkr.ecr.us-east-1.amazonaws.com/distributor-oracle:0.0.2

--- a/argocd/manifests/helium/mobile-oracle.yaml
+++ b/argocd/manifests/helium/mobile-oracle.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: mobile-oracle
+        security-group: rds-access
     spec:
       serviceAccountName: rds-mobile-oracle-user-access
       containers:

--- a/argocd/manifests/helium/mobile-oracle.yaml
+++ b/argocd/manifests/helium/mobile-oracle.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: mobile-oracle
     spec:
-      serviceAccountName: rds_mobile_oracle_user_access
+      serviceAccountName: rds-mobile-oracle-user-access
       containers:
         - name: mobile-oracle
           image: 177106435319.dkr.ecr.us-east-1.amazonaws.com/distributor-oracle:0.0.2

--- a/cluster.tf
+++ b/cluster.tf
@@ -2,16 +2,6 @@ locals {
   cluster_name = "${var.cluster_name}-${var.env}"
 }
 
-data "aws_eks_cluster" "eks" {
-  name = local.cluster_name
-}
-
-data "aws_eks_cluster_auth" "eks" {
-  name = local.cluster_name
-}
-
-data "aws_caller_identity" "current" {}
-
 provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.eks.endpoint

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,25 @@
+data "kubectl_path_documents" "nginx" {
+  pattern = "./lb/ingress-nginx.yaml"
+  vars = {
+    cert = var.zone_cert
+    cidr = var.cidr_block
+  }
+}
+
+data "aws_eks_cluster" "eks" {
+  name = local.cluster_name
+}
+
+data "aws_eks_cluster_auth" "eks" {
+  name = local.cluster_name
+}
+
+data "aws_caller_identity" "current" {}
+
+data "kubectl_path_documents" "application" {
+  pattern = "./argocd/application.yaml"
+}
+
+data "aws_iam_role" "rds_hf_user_access_role" {
+  name = "rds_hf_user_access_role" 
+}

--- a/data.tf
+++ b/data.tf
@@ -20,6 +20,10 @@ data "kubectl_path_documents" "application" {
   pattern = "./argocd/application.yaml"
 }
 
-data "aws_iam_role" "rds_hf_user_access_role" {
-  name = "rds_hf_user_access_role" 
+data "aws_iam_role" "rds_mobile_oracle_user_access_role" {
+  name = "rds_mobile_oracle_user_access_role" 
+}
+
+data "aws_iam_role" "rds_active_device_oracle_user_access_role" {
+  name = "rds_active_device_oracle_user_access_role" 
 }

--- a/data.tf
+++ b/data.tf
@@ -27,3 +27,7 @@ data "aws_iam_role" "rds_mobile_oracle_user_access_role" {
 data "aws_iam_role" "rds_active_device_oracle_user_access_role" {
   name = "rds-active-device-oracle-user-access-role" 
 }
+
+data "aws_security_group" "rds_access_security_group" {
+  name = "rds-access-security-group"
+}

--- a/data.tf
+++ b/data.tf
@@ -21,9 +21,9 @@ data "kubectl_path_documents" "application" {
 }
 
 data "aws_iam_role" "rds_mobile_oracle_user_access_role" {
-  name = "rds_mobile_oracle_user_access_role" 
+  name = "rds-mobile-oracle-user-access-role" 
 }
 
 data "aws_iam_role" "rds_active_device_oracle_user_access_role" {
-  name = "rds_active_device_oracle_user_access_role" 
+  name = "rds-active-device-oracle-user-access-role" 
 }

--- a/external_dns.tf
+++ b/external_dns.tf
@@ -32,17 +32,6 @@ resource "aws_iam_role_policy" "external_dns" {
   policy      = file("${path.module}/policies/external-dns-iam-policy.json")
 }
 
-resource "kubernetes_service_account" "external_dns" {
-  metadata {
-    name      = "external-dns"
-    namespace = "kube-system"
-    annotations = {
-      "eks.amazonaws.com/role-arn" = aws_iam_role.external_dns.arn
-    }
-  }
-  automount_service_account_token = true
-}
-
 resource "kubernetes_cluster_role" "external_dns" {
   metadata {
     name = "external-dns"

--- a/lb.tf
+++ b/lb.tf
@@ -2,7 +2,6 @@ locals {
   lb_role_name = "${local.cluster_name}-aws-load-balancer-controller"
 }
 
-
 resource "aws_iam_role" "lb" {
   name  = local.lb_role_name
 
@@ -33,22 +32,6 @@ resource "aws_iam_role_policy" "lb" {
   policy      = file("${path.module}/policies/lb.json")
 }
 
-resource "kubernetes_service_account" "lb" {
-  metadata {
-    name      = "lb"
-    namespace = "default"
-    annotations = {
-      "eks.amazonaws.com/role-arn" = aws_iam_role.lb.arn,
-      "meta.helm.sh/release-name" = "aws-load-balancer-controller",
-      "meta.helm.sh/release-namespace" = "default",
-    }
-    labels = {
-      "app.kubernetes.io/managed-by" = "Helm",
-    }
-  }
-  automount_service_account_token = true
-}
-
 resource "helm_release" "lbc" {
   name             = "aws-load-balancer-controller"
   chart            = "aws-load-balancer-controller"
@@ -65,14 +48,6 @@ resource "helm_release" "lbc" {
     name = "serviceAccount.name"
     value = "lb"
   }
-}
-
-data "kubectl_path_documents" "nginx" {
-    pattern = "./lb/ingress-nginx.yaml"
-    vars = {
-      cert = var.zone_cert
-      cidr = var.cidr_block
-    }
 }
 
 resource "kubectl_manifest" "nginx" {

--- a/lb.tf
+++ b/lb.tf
@@ -36,7 +36,7 @@ resource "helm_release" "lbc" {
   name             = "aws-load-balancer-controller"
   chart            = "aws-load-balancer-controller"
   version          = "1.4.5"
-  namespace = "default"
+  namespace        = "default"
   repository       = "https://aws.github.io/eks-charts"
   create_namespace = true
   cleanup_on_fail  = true

--- a/security_group_policy.tf
+++ b/security_group_policy.tf
@@ -1,0 +1,16 @@
+resource "kubectl_manifest" "rds-access-security-group-policy" {
+    yaml_body = <<YAML
+apiVersion: vpcresources.k8s.aws/v1beta1
+kind: SecurityGroupPolicy
+metadata:
+  name: rds-access-security-group-policy
+  namespace: helium
+spec:
+  podSelector: 
+    matchLabels: 
+      security-group: rds-access
+  securityGroups:
+    groupIds:
+      - "${data.aws_security_group.rds_access_security_group.id}"
+YAML
+}

--- a/service-accounts.tf
+++ b/service-accounts.tf
@@ -14,12 +14,22 @@ resource "kubernetes_service_account" "lb" {
   automount_service_account_token = true
 }
 
-resource "kubernetes_service_account" "rds-hf-user-access" {
+resource "kubernetes_service_account" "rds_mobile_oracle_user_access" {
   metadata {
-    name        = "rds-hf-user-access"
+    name        = "rds_mobile_oracle_user_access"
     namespace   = "default"
     annotations = {
-      "eks.amazonaws.com/role-arn" = data.aws_iam_role.rds_hf_user_access_role.arn,
+      "eks.amazonaws.com/role-arn" = data.aws_iam_role.rds_mobile_oracle_user_access_role.arn,
+    }
+  }
+}
+
+resource "kubernetes_service_account" "rds_active_device_oracle_user_access" {
+  metadata {
+    name        = "rds_active_device_oracle_user_access"
+    namespace   = "default"
+    annotations = {
+      "eks.amazonaws.com/role-arn" = data.aws_iam_role.rds_active_device_oracle_user_access_role.arn,
     }
   }
 }

--- a/service-accounts.tf
+++ b/service-accounts.tf
@@ -16,7 +16,7 @@ resource "kubernetes_service_account" "lb" {
 
 resource "kubernetes_service_account" "rds_mobile_oracle_user_access" {
   metadata {
-    name        = "rds_mobile_oracle_user_access"
+    name        = "rds-mobile-oracle-user-access"
     namespace   = "default"
     annotations = {
       "eks.amazonaws.com/role-arn" = data.aws_iam_role.rds_mobile_oracle_user_access_role.arn,
@@ -26,7 +26,7 @@ resource "kubernetes_service_account" "rds_mobile_oracle_user_access" {
 
 resource "kubernetes_service_account" "rds_active_device_oracle_user_access" {
   metadata {
-    name        = "rds_active_device_oracle_user_access"
+    name        = "rds-active-device-oracle-user-access"
     namespace   = "default"
     annotations = {
       "eks.amazonaws.com/role-arn" = data.aws_iam_role.rds_active_device_oracle_user_access_role.arn,

--- a/service-accounts.tf
+++ b/service-accounts.tf
@@ -1,0 +1,25 @@
+resource "kubernetes_service_account" "lb" {
+  metadata {
+    name      = "lb"
+    namespace = "default"
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.lb.arn,
+      "meta.helm.sh/release-name" = "aws-load-balancer-controller",
+      "meta.helm.sh/release-namespace" = "default",
+    }
+    labels = {
+      "app.kubernetes.io/managed-by" = "Helm",
+    }
+  }
+  automount_service_account_token = true
+}
+
+resource "kubernetes_service_account" "rds-hf-user-access" {
+  metadata {
+    name        = "rds-hf-user-access"
+    namespace   = "default"
+    annotations = {
+      "eks.amazonaws.com/role-arn" = data.aws_iam_role.rds_hf_user_access_role.arn,
+    }
+  }
+}

--- a/service_accounts.tf
+++ b/service_accounts.tf
@@ -14,10 +14,21 @@ resource "kubernetes_service_account" "lb" {
   automount_service_account_token = true
 }
 
+resource "kubernetes_service_account" "external_dns" {
+  metadata {
+    name      = "external-dns"
+    namespace = "kube-system"
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.external_dns.arn
+    }
+  }
+  automount_service_account_token = true
+}
+
 resource "kubernetes_service_account" "rds_mobile_oracle_user_access" {
   metadata {
     name        = "rds-mobile-oracle-user-access"
-    namespace   = "default"
+    namespace   = "helium"
     annotations = {
       "eks.amazonaws.com/role-arn" = data.aws_iam_role.rds_mobile_oracle_user_access_role.arn,
     }
@@ -27,7 +38,7 @@ resource "kubernetes_service_account" "rds_mobile_oracle_user_access" {
 resource "kubernetes_service_account" "rds_active_device_oracle_user_access" {
   metadata {
     name        = "rds-active-device-oracle-user-access"
-    namespace   = "default"
+    namespace   = "helium"
     annotations = {
       "eks.amazonaws.com/role-arn" = data.aws_iam_role.rds_active_device_oracle_user_access_role.arn,
     }


### PR DESCRIPTION
This PR:

- Adds two service accounts, `rds_mobile_oracle_user_access` and `rds_active_device_oracle_user_access`, respectively for the `mobile_oracle` and `active_device_oracle` pods to access postgres users of same names.
- Adds the service accounts to the `mobile_oracle` and `active_device_oracle` pods
- Adds pod-level security groups
- Creates `service-account.tf`
- Creates `data.tf`
- Refactors into `service-account.tf` and `data.tf`