### PR TITLE
Pod-level sg updates

### DIFF
--- a/argocd/manifests/helium/active-device-oracle.yaml
+++ b/argocd/manifests/helium/active-device-oracle.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: active-device-oracle
+        security-group: rds-access
     spec:
       containers:
         - name: active-device-oracle

--- a/argocd/manifests/monitoring/grafana/grafana.yaml
+++ b/argocd/manifests/monitoring/grafana/grafana.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: grafana-pvc
+  name: grafana-pvc-1
   namespace: monitoring
 spec:
   accessModes:

--- a/argocd/manifests/monitoring/grafana/grafana.yaml
+++ b/argocd/manifests/monitoring/grafana/grafana.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: grafana-pvc-1
+  name: grafana-pvc
   namespace: monitoring
 spec:
   accessModes:

--- a/security_group_policy.tf
+++ b/security_group_policy.tf
@@ -12,6 +12,6 @@ spec:
   securityGroups:
     groupIds:
       - "${data.aws_security_group.rds_access_security_group.id}"
-      - "${data.aws_eks_cluster.eks.vpc_config.cluster_security_group_id}"
+      - "${data.aws_eks_cluster.eks.vpc_config[0].cluster_security_group_id}"
 YAML
 }

--- a/security_group_policy.tf
+++ b/security_group_policy.tf
@@ -12,5 +12,6 @@ spec:
   securityGroups:
     groupIds:
       - "${data.aws_security_group.rds_access_security_group.id}"
+      - "${data.aws_eks_cluster.eks.vpc_config.cluster_security_group_id}"
 YAML
 }


### PR DESCRIPTION
This PR:

- Adds `security-group: rds-access` label back to `active-device-oracle`
- Adds primary cluster sg to list of sgs applied to pods