### PR TITLE
Horizontal pod autoscaler

### DIFF
--- a/manifests/oracle-cluster/prod/helium/iot-oracle.yaml
+++ b/manifests/oracle-cluster/prod/helium/iot-oracle.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       app: iot-oracle
+  replicas: 5  
   template:
     metadata:
       labels:
@@ -79,7 +80,6 @@ spec:
               cpu: 250m
               memory: 500Mi
             limits:
-              cpu: 500m
               memory: 750Mi
       volumes:
         - name: oracle-keypair
@@ -122,3 +122,29 @@ spec:
             name: iot-oracle
             port:
               number: 8080
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: iot-oracle
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: iot-oracle
+  minReplicas: 5
+  maxReplicas: 20
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/oracle-cluster/prod/helium/mobile-oracle.yaml
+++ b/manifests/oracle-cluster/prod/helium/mobile-oracle.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       app: mobile-oracle
+  replicas: 5  
   template:
     metadata:
       labels:
@@ -79,7 +80,6 @@ spec:
               cpu: 250m
               memory: 500Mi
             limits:
-              cpu: 500m
               memory: 750Mi
       volumes:
         - name: oracle-keypair
@@ -122,3 +122,29 @@ spec:
             name: mobile-oracle
             port:
               number: 8080
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: mobile-oracle
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mobile-oracle
+  minReplicas: 5
+  maxReplicas: 20
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/web-cluster/prod/helium/metadata.yaml
+++ b/manifests/web-cluster/prod/helium/metadata.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       app: metadata
+  replicas: 4
   template:
     metadata:
       labels:
@@ -58,7 +59,6 @@ spec:
               cpu: 250m
               memory: 500Mi
             limits:
-              cpu: 500m
               memory: 750Mi
 ---
 apiVersion: v1
@@ -94,3 +94,29 @@ spec:
             name: metadata
             port:
               number: 8081
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: metadata
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: metadata
+  minReplicas: 4
+  maxReplicas: 15
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/web-cluster/prod/helium/migration-service.yaml
+++ b/manifests/web-cluster/prod/helium/migration-service.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       app: migration-service
+  replicas: 5
   template:
     metadata:
       labels:
@@ -51,7 +52,6 @@ spec:
               cpu: 250m
               memory: 500Mi
             limits:
-              cpu: 500m
               memory: 750Mi
 ---
 apiVersion: v1
@@ -87,3 +87,29 @@ spec:
             name: migration-service
             port:
               number: 8081
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: migration-service
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: migration-service
+  minReplicas: 5
+  maxReplicas: 20
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/web-cluster/prod/helium/onboarding-server.yaml
+++ b/manifests/web-cluster/prod/helium/onboarding-server.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       app: onboarding-server
+  replicas: 2
   template:
     metadata:
       labels:
@@ -73,7 +74,6 @@ spec:
               cpu: 250m
               memory: 500Mi
             limits:
-              cpu: 500m
               memory: 750Mi
 ---
 apiVersion: v1
@@ -109,3 +109,29 @@ spec:
             name: onboarding-server
             port:
               number: 3002
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: onboarding-server
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: onboarding-server
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/web-cluster/prod/helium/solana-monitor.yaml
+++ b/manifests/web-cluster/prod/helium/solana-monitor.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: solana-monitor
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:
@@ -87,29 +87,3 @@ spec:
     app: solana-monitor
   sessionAffinity: None
   type: LoadBalancer
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: solana-monitor
-  namespace: helium
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: solana-monitor
-  minReplicas: 2
-  maxReplicas: 5
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 75
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 75

--- a/manifests/web-cluster/prod/helium/solana-monitor.yaml
+++ b/manifests/web-cluster/prod/helium/solana-monitor.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       app: solana-monitor
+  replicas: 2
   template:
     metadata:
       labels:
@@ -86,3 +87,29 @@ spec:
     app: solana-monitor
   sessionAffinity: None
   type: LoadBalancer
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: solana-monitor
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: solana-monitor
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/web-cluster/prod/helium/vsr-metadata.yaml
+++ b/manifests/web-cluster/prod/helium/vsr-metadata.yaml
@@ -87,3 +87,29 @@ spec:
             name: vsr-metadata
             port:
               number: 8081
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: vsr-metadata
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: vsr-metadata
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/web-cluster/sdlc/helium/metadata.yaml
+++ b/manifests/web-cluster/sdlc/helium/metadata.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       app: metadata
+  replicas: 1
   template:
     metadata:
       labels:
@@ -58,7 +59,6 @@ spec:
               cpu: 250m
               memory: 500Mi
             limits:
-              cpu: 500m
               memory: 750Mi
 ---
 apiVersion: v1
@@ -94,3 +94,29 @@ spec:
             name: metadata
             port:
               number: 8081
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: metadata
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: metadata
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/web-cluster/sdlc/helium/migration-service.yaml
+++ b/manifests/web-cluster/sdlc/helium/migration-service.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       app: migration-service
+  replicas: 1
   template:
     metadata:
       labels:
@@ -51,7 +52,6 @@ spec:
               cpu: 250m
               memory: 500Mi
             limits:
-              cpu: 500m
               memory: 750Mi
 ---
 apiVersion: v1
@@ -87,3 +87,29 @@ spec:
             name: migration-service
             port:
               number: 8081
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: migration-service
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: migration-service
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/web-cluster/sdlc/helium/onboarding-server.yaml
+++ b/manifests/web-cluster/sdlc/helium/onboarding-server.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       app: onboarding-server
+  replicas: 1
   template:
     metadata:
       labels:
@@ -73,7 +74,6 @@ spec:
               cpu: 250m
               memory: 500Mi
             limits:
-              cpu: 500m
               memory: 750Mi
 ---
 apiVersion: v1
@@ -109,3 +109,29 @@ spec:
             name: onboarding-server
             port:
               number: 3002
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: onboarding-server
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: onboarding-server
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/web-cluster/sdlc/helium/solana-monitor.yaml
+++ b/manifests/web-cluster/sdlc/helium/solana-monitor.yaml
@@ -87,29 +87,3 @@ spec:
     app: solana-monitor
   sessionAffinity: None
   type: LoadBalancer
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: solana-monitor
-  namespace: helium
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: solana-monitor
-  minReplicas: 1
-  maxReplicas: 3
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 75
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 75

--- a/manifests/web-cluster/sdlc/helium/solana-monitor.yaml
+++ b/manifests/web-cluster/sdlc/helium/solana-monitor.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       app: solana-monitor
+  replicas: 1
   template:
     metadata:
       labels:
@@ -86,3 +87,29 @@ spec:
     app: solana-monitor
   sessionAffinity: None
   type: LoadBalancer
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: solana-monitor
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: solana-monitor
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/web-cluster/sdlc/helium/vsr-metadata.yaml
+++ b/manifests/web-cluster/sdlc/helium/vsr-metadata.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       app: vsr-metadata
+  replicas: 1  
   template:
     metadata:
       labels:
@@ -87,3 +88,29 @@ spec:
             name: vsr-metadata
             port:
               number: 8081
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: vsr-metadata
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: vsr-metadata
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75


### PR DESCRIPTION
This PR:

- Adds `HorizontalPodAutoscaler` for each helium namespace pod in `oracle` and `web` accounts
- Defines `minReplicas` and `maxReplicas` in `HPA` along with cpu and memory usage thresholds
- Adds `replicas` count to helium namespace Deployments
- Removes cpu limits from mission critical helium namespace Deployments e.g., https://home.robusta.dev/blog/stop-using-cpu-limits?nocache=234

## Pods / EC2s per env
**web-sdlc**
`metadata`:                 1 pod min - 1 pod set - 3 pods max
`migration-service`:   1 pod min - 1 pod set - 3 pods max
`onboarding-server`: 1 pod min - 1 pod set - 3 pods max
`solana-monitor`:       1 pod min - 1 pod set - 1 pods max
`vsr-metadata`:          1 pod min - 1 pod set - 3 pods max
`EC2s (m5.large)`:     2 min - 2 set - 5 max

**web-prod**
`metadata`:                 4 pod min - 4 pod set - 15 pods max
`migration-service`:   5 pod min - 5 pod set - 20 pods max
`onboarding-server`: 2 pod min - 2 pod set - 5 pods max
`solana-monitor`:       1 pod min - 1 pod set - 1 pods max
`vsr-metadata`:          2 pod min - 2 pod set - 5 pods max
`EC2s (m5.large)`:     4 min - 4 set - 15 max   

**oracle-prod**
`iot-oracle`:            5 pod min - 5 pod set - 20 pods max
`mobile-oracle`:     5 pod min - 5 pod set - 20 pods max
`EC2s (m5.large)`: 3 min - 3 set - 11 max                   