### PR TITLE
Bump 0.0.40

### DIFF
--- a/manifests/oracle-cluster/prod/helium/iot-oracle.yaml
+++ b/manifests/oracle-cluster/prod/helium/iot-oracle.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: iot-oracle 
+      app: iot-oracle
   template:
     metadata:
       labels:
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: rds-iot-oracle-user-access
       containers:
         - name: iot-oracle
-          image: public.ecr.aws/j4f9f0n7/distributor-oracle:0.0.39
+          image: public.ecr.aws/j4f9f0n7/distributor-oracle:0.0.40
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/manifests/oracle-cluster/prod/helium/mobile-oracle.yaml
+++ b/manifests/oracle-cluster/prod/helium/mobile-oracle.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: mobile-oracle 
+      app: mobile-oracle
   template:
     metadata:
       labels:
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: rds-mobile-oracle-user-access
       containers:
         - name: mobile-oracle
-          image: public.ecr.aws/j4f9f0n7/distributor-oracle:0.0.39
+          image: public.ecr.aws/j4f9f0n7/distributor-oracle:0.0.40
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/manifests/oracle-cluster/sdlc/helium/iot-oracle.yaml
+++ b/manifests/oracle-cluster/sdlc/helium/iot-oracle.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: rds-iot-oracle-user-access
       containers:
         - name: iot-oracle
-          image: public.ecr.aws/s2o4r1i6/distributor-oracle:0.0.39
+          image: public.ecr.aws/s2o4r1i6/distributor-oracle:0.0.40
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/manifests/oracle-cluster/sdlc/helium/mobile-oracle.yaml
+++ b/manifests/oracle-cluster/sdlc/helium/mobile-oracle.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: rds-mobile-oracle-user-access
       containers:
         - name: mobile-oracle
-          image: public.ecr.aws/s2o4r1i6/distributor-oracle:0.0.39
+          image: public.ecr.aws/s2o4r1i6/distributor-oracle:0.0.40
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Heads up, just mirrored what @ThornM9 did [here](https://github.com/helium/helium-foundation-k8s/commit/d1cd7d1cb5de7d932957bdaef407c0301dc1ae8b). Pushed a new image to oracle-sdlc (0.0.40) which is the `s2o4r1i6`/distributor-oracle:0.0.40 image. The `j4f9f0n7`/distributor-oracle:0.0.40 doesn't exist as there hasn't been an image pushed to oracle-prod