### PR TITLE
fix(bump-distributor-oracle-to-0.0.46-on-prod)

### DIFF
--- a/manifests/oracle-cluster/prod/helium/iot-oracle.yaml
+++ b/manifests/oracle-cluster/prod/helium/iot-oracle.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: rds-iot-oracle-user-access
       containers:
         - name: iot-oracle
-          image: public.ecr.aws/s2o4r1i6/distributor-oracle:0.0.44
+          image: public.ecr.aws/s2o4r1i6/distributor-oracle:0.0.46
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/manifests/oracle-cluster/prod/helium/mobile-oracle.yaml
+++ b/manifests/oracle-cluster/prod/helium/mobile-oracle.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: rds-mobile-oracle-user-access
       containers:
         - name: mobile-oracle
-          image: public.ecr.aws/s2o4r1i6/distributor-oracle:0.0.44
+          image: public.ecr.aws/s2o4r1i6/distributor-oracle:0.0.46
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
was unable to parse non bs58 keys