### PR TITLE
Updating poc-data for job retention

### DIFF
--- a/manifests/poc-data-cluster/prod/helium/active-hotspot-oracle-iot.yaml
+++ b/manifests/poc-data-cluster/prod/helium/active-hotspot-oracle-iot.yaml
@@ -17,13 +17,8 @@ spec:
         spec:
           serviceAccountName: s3-data-lake-bucket-access
           # Temporarily commenting out to enable log review
-          tolerations: # Schedule executor pods on spot-helium instance group
-            - key: dedicated
-              operator: Equal
-              value: spot-spark
-              effect: NoSchedule
           nodeSelector:
-            nodegroup-type: spot-spark
+            nodegroup-type: medium
           containers:
           - name: active-hotspot-oracle-iot
             image: public.ecr.aws/k0m1p4t7/active-hotspot-oracle:0.0.17
@@ -57,7 +52,7 @@ spec:
                 memory: 5Gi
               limits:
                 memory: 5Gi
-          restartPolicy: OnFailure
+          restartPolicy: Never
           volumes:
             - name: active-hotspot-oracle-keypair
               secret:

--- a/manifests/poc-data-cluster/prod/helium/active-hotspot-oracle-mobile.yaml
+++ b/manifests/poc-data-cluster/prod/helium/active-hotspot-oracle-mobile.yaml
@@ -16,13 +16,8 @@ spec:
       template:
         spec:
           serviceAccountName: s3-data-lake-bucket-access
-          tolerations: # Schedule executor pods on spot-helium instance group
-            - key: dedicated
-              operator: Equal
-              value: spot-spark
-              effect: NoSchedule
           nodeSelector:
-            nodegroup-type: spot-spark
+            nodegroup-type: medium
           containers:
           - name: active-hotspot-oracle-mobile
             image: public.ecr.aws/k0m1p4t7/active-hotspot-oracle:0.0.17
@@ -56,7 +51,7 @@ spec:
                 memory: 5Gi
               limits:
                 memory: 5Gi
-          restartPolicy: OnFailure
+          restartPolicy: Never
           volumes:
             - name: active-hotspot-oracle-keypair
               secret:

--- a/manifests/poc-data-cluster/prod/helium/iot-rewards-share-delta-lake-sink.yaml
+++ b/manifests/poc-data-cluster/prod/helium/iot-rewards-share-delta-lake-sink.yaml
@@ -16,13 +16,8 @@ spec:
       template:
         spec:
           serviceAccountName: s3-data-lake-bucket-access
-          tolerations: # Schedule executor pods on spot-helium instance group
-            - key: dedicated
-              operator: Equal
-              value: spot-helium
-              effect: NoSchedule
           nodeSelector:
-            nodegroup-type: spot-helium
+            nodegroup-type: medium
           containers:
           - name: iot-rewards-delta-lake-sink
             image: public.ecr.aws/k0m1p4t7/protobuf-delta-lake-sink:0.0.17
@@ -67,4 +62,4 @@ spec:
               - "86400"
               - --batch-size
               - "500000000" # Targetting 500mb parquet files, per databricks recs on large tables
-          restartPolicy: OnFailure
+          restartPolicy: Never

--- a/manifests/poc-data-cluster/prod/helium/mobile-rewards-share-delta-lake-sink.yaml
+++ b/manifests/poc-data-cluster/prod/helium/mobile-rewards-share-delta-lake-sink.yaml
@@ -16,13 +16,8 @@ spec:
       template:
         spec:
           serviceAccountName: s3-data-lake-bucket-access
-          tolerations: # Schedule executor pods on spot-helium instance group
-            - key: dedicated
-              operator: Equal
-              value: spot-helium
-              effect: NoSchedule
           nodeSelector:
-            nodegroup-type: spot-helium
+            nodegroup-type: medium
           containers:
           - name: mobile-rewards-delta-lake-sink
             image: public.ecr.aws/k0m1p4t7/protobuf-delta-lake-sink:0.0.17
@@ -69,4 +64,4 @@ spec:
               - "86400"
               - --batch-size
               - "500000000" # Targetting 500mb parquet files, per databricks recs on large tables
-          restartPolicy: OnFailure
+          restartPolicy: Never


### PR DESCRIPTION
The CronJob will create a Job which will in turn create up to 10 discrete, non-overlapping Pods where a new Pod is created after a previous Pod enters the error state.

