### PR TITLE
Updating handling of spark k8s resources

### DIFF
--- a/manifests/poc-data-cluster/prod/spark/iot-hotspot-rewards-silver.yaml
+++ b/manifests/poc-data-cluster/prod/spark/iot-hotspot-rewards-silver.yaml
@@ -25,7 +25,7 @@ spec:
   schedule: "30 2 * * *"
   concurrencyPolicy: Forbid
   successfulRunHistoryLimit: 1
-  failedRunHistoryLimit: 5
+  failedRunHistoryLimit: 1
   template:
     type: Scala
     mode: cluster
@@ -34,6 +34,8 @@ spec:
     mainClass: Main
     mainApplicationFile: "s3a://foundation-data-lake-requester-pays/jars/spark-streaming-sql-assembly-1.0.2.jar"
     sparkVersion: "3.4.0"
+    failureRetries: 3
+    retryInterval: 10
     restartPolicy:
       type: OnFailure
       onFailureRetries: 3
@@ -61,7 +63,7 @@ spec:
       coreLimit: "1200m"
       memory: "512m"
       nodeSelector:
-        node.kubernetes.io/instance-type: m5.large
+        nodegroup-type: medium
       envVars:
         TABLE_IOT_REWARD_SHARE: s3a://foundation-data-lake-requester-pays/bronze/iot_reward_share
         PARTITION_BY: "date"
@@ -82,6 +84,7 @@ spec:
       coreLimit: "1200m"
       instances: 2
       memory: "10G"
+      deleteOnTermination: false
       tolerations: # Schedule executor pods on spot-spark instance group
         - key: dedicated
           operator: Equal

--- a/manifests/poc-data-cluster/prod/spark/mobile-hotspot-rewards-silver.yaml
+++ b/manifests/poc-data-cluster/prod/spark/mobile-hotspot-rewards-silver.yaml
@@ -26,7 +26,7 @@ spec:
   schedule: "30 2 * * *"
   concurrencyPolicy: Forbid
   successfulRunHistoryLimit: 1
-  failedRunHistoryLimit: 5
+  failedRunHistoryLimit: 1
   template:
     type: Scala
     mode: cluster
@@ -35,6 +35,8 @@ spec:
     mainClass: Main
     mainApplicationFile: "s3a://foundation-data-lake-requester-pays/jars/spark-streaming-sql-assembly-1.0.2.jar"
     sparkVersion: "3.4.0"
+    failureRetries: 3
+    retryInterval: 10
     restartPolicy:
       type: OnFailure
       onFailureRetries: 3
@@ -61,6 +63,8 @@ spec:
       cores: 1
       coreLimit: "1200m"
       memory: "512m"
+      nodeSelector:
+        nodegroup-type: medium
       envVars:
         TABLE_MOBILE_REWARD_SHARE: s3a://foundation-data-lake-requester-pays/bronze/mobile_reward_share
         PARTITION_BY: "date"
@@ -81,6 +85,7 @@ spec:
       coreLimit: "1200m"
       instances: 1
       memory: "5G"
+      deleteOnTermination: false
       tolerations: # Schedule executor pods on spot-spark instance group
         - key: dedicated
           operator: Equal

--- a/manifests/poc-data-cluster/prod/spark/recently-rewarded-hotspots-gold.yaml
+++ b/manifests/poc-data-cluster/prod/spark/recently-rewarded-hotspots-gold.yaml
@@ -33,7 +33,7 @@ spec:
   schedule: "0 3 * * *"
   concurrencyPolicy: Forbid
   successfulRunHistoryLimit: 1
-  failedRunHistoryLimit: 5
+  failedRunHistoryLimit: 1
   template:
     type: Scala
     mode: cluster
@@ -42,6 +42,8 @@ spec:
     mainClass: Main
     mainApplicationFile: "s3a://foundation-data-lake-requester-pays/jars/spark-streaming-sql-assembly-1.0.2.jar"
     sparkVersion: "3.4.0"
+    failureRetries: 3
+    retryInterval: 10
     restartPolicy:
       type: OnFailure
       onFailureRetries: 3
@@ -68,6 +70,8 @@ spec:
       cores: 1
       coreLimit: "1200m"
       memory: "512m"
+      nodeSelector:
+        nodegroup-type: medium
       envVars:
         TABLE_MOBILE_HOTSPOT_REWARDS: s3a://foundation-data-lake-requester-pays/silver/mobile-hotspot-rewards
         TABLE_IOT_HOTSPOT_REWARDS: s3a://foundation-data-lake-requester-pays/silver/iot-hotspot-rewards
@@ -87,6 +91,7 @@ spec:
       coreLimit: "1200m"
       instances: 3
       memory: "6G"
+      deleteOnTermination: false
       tolerations: # Schedule executor pods on spot-spark instance group
         - key: dedicated
           operator: Equal


### PR DESCRIPTION
Ideally this will result in both `driver` and `executor` pods being persisted for around 24 hours which will allow the `KubernetesPodNotHealthy` alert to catch and give us an opportunity to review logs.