### PR TITLE
increase my-helium HPA maxReplicas from 3 to 5

### DIFF
--- a/manifests/web-cluster/prod/helium/my-helium.yaml
+++ b/manifests/web-cluster/prod/helium/my-helium.yaml
@@ -248,7 +248,7 @@ spec:
     kind: Deployment
     name: my-helium
   minReplicas: 1
-  maxReplicas: 3
+  maxReplicas: 5
   metrics:
     - type: Resource
       resource:


### PR DESCRIPTION
my-helium is hitting the HPA ceiling (3/3 replicas) with memory at 62% — bumping max to 5 to let it scale.