### PR TITLE
Tuktuk pyth v2

### DIFF
--- a/manifests/web-cluster/prod/helium/sealed-pyth-api-key.yaml
+++ b/manifests/web-cluster/prod/helium/sealed-pyth-api-key.yaml
@@ -1,0 +1,25 @@
+# TODO(pyth-upgrade/07): This is a PLACEHOLDER. The Pyth data-plan API key does
+# not exist yet. Once the key is procured, seal it against the PROD web-cluster
+# sealed-secrets controller and replace encryptedData.secret below, e.g.:
+#
+#   echo -n "$PYTH_API_KEY" | kubeseal --raw \
+#     --namespace helium --name pyth-api-key \
+#     --controller-namespace kube-system --controller-name sealed-secrets \
+#     > sealed.txt
+#
+# Do NOT deploy this file with the placeholder value.
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: pyth-api-key
+  namespace: helium
+spec:
+  encryptedData:
+    secret: REPLACE_ME_WITH_SEALED_PYTH_API_KEY
+  template:
+    metadata:
+      creationTimestamp: null
+      name: pyth-api-key
+      namespace: helium

--- a/manifests/web-cluster/prod/helium/sealed-pyth-api-key.yaml
+++ b/manifests/web-cluster/prod/helium/sealed-pyth-api-key.yaml
@@ -1,13 +1,8 @@
-# TODO(pyth-upgrade/07): This is a PLACEHOLDER. The Pyth data-plan API key does
-# not exist yet. Once the key is procured, seal it against the PROD web-cluster
-# sealed-secrets controller and replace encryptedData.secret below, e.g.:
+# Sealed against the PROD web-cluster sealed-secrets controller. To rotate:
 #
 #   echo -n "$PYTH_API_KEY" | kubeseal --raw \
 #     --namespace helium --name pyth-api-key \
-#     --controller-namespace kube-system --controller-name sealed-secrets \
-#     > sealed.txt
-#
-# Do NOT deploy this file with the placeholder value.
+#     --controller-namespace kube-system --controller-name sealed-secrets-controller
 ---
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
@@ -17,7 +12,7 @@ metadata:
   namespace: helium
 spec:
   encryptedData:
-    secret: REPLACE_ME_WITH_SEALED_PYTH_API_KEY
+    secret: AgBAib5dvMARzy6zs9O3UDpCCz1JcLD8zbOQKjde7OBDEtQE1Tvv7YpFHaT3+b+5aUv4TaMFaiDGHJkpI//HcXdrKQ2dJR41EzRMEI6iMj7m3lJgmDUz61zqe6bZdKIXUe04fyGYDe1IHXEF17BsRXQK/Ggh31vF88NAsbxqzmwG8akCkCc0++OaOz84exWMAqNkMGdlvSlL6MNTRm186Y8D3Bh3oQsUN/Qrb6/2UBdC6nvOlrqTUzFeMnsgQiodejWjOZPOCryhsuZgCCfWcNEJW7QJVGpMXpwidt81u0DS1eMzp7/SS9Y80LmPJbXfEewK5y5gk+oGWKL6HVWAc7ipOoi1AqQkzoXM+mkgwVq72OgLx/BtOsV9s2Qs1vhL4YCz74fRfikmPo/ITU8aw0xMHxs2hlJ9d7AiqyVph8zM7ZPCTOviOxJpM6BeYLHFMFrL+Fbo64Y5cLvpBApnYZyy4Z0r2YNzTU9KWbK8WDn+mf6peFjniD65C7FgA+cQBojFSlC2FmUyAQOFI0HU2Gn5r7BTpvnba8nniGKAm4paq8PvGaX4JMdmO1vzGqIG0G7iOKBlozM5SbEZo6PgGSX1faoxUZ2EpRHqER2KAyxX/jG08L80+xB4jVMUySom1VrE5pEQaLq/aU1zdGnVWri4IQCjcwo8deSFkzGuMRURz3IhiWOQso+b5cAop1DVMV7sC3x0hTESj1usfPKUKRm2OVaL/0onqoR5S0IwkxVtrtUeVcvSfszoTRx6hQ==
   template:
     metadata:
       creationTimestamp: null

--- a/manifests/web-cluster/prod/helium/tuktuk-pyth-v2.yaml
+++ b/manifests/web-cluster/prod/helium/tuktuk-pyth-v2.yaml
@@ -1,0 +1,163 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tuktuk-pyth-v2
+  name: tuktuk-pyth-v2
+  namespace: helium
+spec:
+  selector:
+    matchLabels:
+      app: tuktuk-pyth-v2
+  template:
+    metadata:
+      labels:
+        app: tuktuk-pyth-v2
+        security-group: public-rds-access
+    spec:
+      serviceAccountName: public-monitoring-rds-monitoring-user-access
+      containers:
+        # TODO(pyth-upgrade/02): pin to the parameterized crank build that
+        # supports the PYTH_* env vars below. 0.0.6 predates parameterization.
+        - name: tuktuk-pyth-v2
+          image: public.ecr.aws/v0j6k5v6/tuktuk-pyth-service:TODO-PARAMETERIZED-BUILD
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8081
+              name: http
+              protocol: TCP
+          env:
+            - name: SOLANA_URL
+              valueFrom:
+                secretKeyRef:
+                  name: helius-rpc-url
+                  key: secret
+            - name: PGHOST
+              value: monitoring-rds.cbhihwhsofyu.us-west-2.rds.amazonaws.com
+            - name: PGPORT
+              value: "5432"
+            - name: PGUSER
+              value: monitoring
+            - name: AWS_REGION
+              value: us-west-2
+            - name: PGDATABASE
+              value: monitoring
+            - name: PGSSLMODE
+              value: no-verify
+            - name: KEYPAIR_PATH
+              value: /usr/src/app/keys/keypair.json
+            - name: ORIGIN
+              value: https://tuktuk-pyth-v2.web.helium.io
+            - name: PYTH_HERMES_URL
+              value: https://pyth.dourolabs.app/hermes/
+            - name: PYTH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-api-key
+                  key: secret
+            - name: PYTH_RECEIVER_PROGRAM_ID
+              value: rec2HHDDnjLfj4kE7VyEtFA1HPGQLK33259532cRyHp
+            - name: PYTH_PUSH_ORACLE_PROGRAM_ID
+              value: pyt2F414BA6dPttK6RddPZUdHfapoBN24GL5wbrPCou
+            - name: WORMHOLE_PROGRAM_ID
+              value: HDw2E7P8X1SkCyjvoGsfBGAVUutKcj874bXjHrpVYrVL
+
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: 8081
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 8081
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: tuktuk-pyth-keypair
+              mountPath: /usr/src/app/keys
+              readOnly: true
+          resources:
+            requests:
+              cpu: 200m
+              memory: 300Mi
+            limits:
+              cpu: 400m
+              memory: 400Mi
+      volumes:
+        - name: tuktuk-pyth-keypair
+          secret:
+            secretName: tuktuk-pyth-keypair
+            items:
+              - key: keypair.json
+                path: keypair.json
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tuktuk-pyth-v2
+  namespace: helium
+spec:
+  ports:
+    - port: 8081
+      protocol: TCP
+      targetPort: http
+  selector:
+    app: tuktuk-pyth-v2
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tuktuk-pyth-v2
+  namespace: helium
+  annotations:
+    nginx.ingress.kubernetes.io/limit-rps: "10"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "10"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: tuktuk-pyth-v2.web.helium.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tuktuk-pyth-v2
+                port:
+                  number: 8081
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: tuktuk-pyth-v2
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: tuktuk-pyth-v2
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/web-cluster/prod/helium/tuktuk-pyth-v2.yaml
+++ b/manifests/web-cluster/prod/helium/tuktuk-pyth-v2.yaml
@@ -20,7 +20,7 @@ spec:
         # TODO(pyth-upgrade/02): pin to the parameterized crank build that
         # supports the PYTH_* env vars below. 0.0.6 predates parameterization.
         - name: tuktuk-pyth-v2
-          image: public.ecr.aws/v0j6k5v6/tuktuk-pyth-service:0.0.7
+          image: public.ecr.aws/v0j6k5v6/tuktuk-pyth-service:0.0.8
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8081

--- a/manifests/web-cluster/prod/helium/tuktuk-pyth-v2.yaml
+++ b/manifests/web-cluster/prod/helium/tuktuk-pyth-v2.yaml
@@ -20,7 +20,7 @@ spec:
         # TODO(pyth-upgrade/02): pin to the parameterized crank build that
         # supports the PYTH_* env vars below. 0.0.6 predates parameterization.
         - name: tuktuk-pyth-v2
-          image: public.ecr.aws/v0j6k5v6/tuktuk-pyth-service:TODO-PARAMETERIZED-BUILD
+          image: public.ecr.aws/v0j6k5v6/tuktuk-pyth-service:0.0.7
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8081

--- a/manifests/web-cluster/sdlc/helium/sealed-pyth-api-key.yaml
+++ b/manifests/web-cluster/sdlc/helium/sealed-pyth-api-key.yaml
@@ -1,13 +1,8 @@
-# TODO(pyth-upgrade/07): This is a PLACEHOLDER. The Pyth data-plan API key does
-# not exist yet. Once the key is procured, seal it against the SDLC web-cluster
-# sealed-secrets controller and replace encryptedData.secret below, e.g.:
+# Sealed against the SDLC web-cluster sealed-secrets controller. To rotate:
 #
 #   echo -n "$PYTH_API_KEY" | kubeseal --raw \
 #     --namespace helium --name pyth-api-key \
-#     --controller-namespace kube-system --controller-name sealed-secrets \
-#     > sealed.txt
-#
-# Do NOT deploy this file with the placeholder value.
+#     --controller-namespace kube-system --controller-name sealed-secrets-controller
 ---
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
@@ -17,7 +12,7 @@ metadata:
   namespace: helium
 spec:
   encryptedData:
-    secret: REPLACE_ME_WITH_SEALED_PYTH_API_KEY
+    secret: AgDAFwGRwGbqQKpqq4WbBTw+YCoHEmdYEmWvGt5l9Cv6ypYuDbFl7kQlfx8jJdn83aGauYcuK3WLgscg6f+3l6tyDyPdiY4S65jdyjWB4WEQTCUtvhXcFUBBrMWczJFDdlvGTRLg5GbjSdgtqz2QMBZ7fFI861DebpX0pfqJBqeu9Ghw5DQvToet7AkiRXrtuZdzWlVa2KyoIm2NX0Y+AyR5PYcCR4V8b7l7xV4aEXGbcJLE0Q39vEIyretD7tGMrSG9E+pK5/IOGmN2Pb7oqoQCLXhAc+Qd+nycA/j44HuqnxQ3GFYV1iEATGHrfRxdnMpcYQ19aw0Oede3H7le+cMLm0UeLQXIis4LruyxccUADY3xgGBCYJ/Z+F/NEZnm6+ZUUcJJdnPavHCf5w4o4/1PRgMg4VR9Pu7VgvwvIRvaVyhgocwR/KWDuu4pPxaq+cFOHjQJR+H/0DRUPy0DMjYYE53jqQNpns43Cx26jWdFk/Ic4yiTe/lSLsO+FrP9SBYTlc+5glSrMuG0OqNGuQiCiSboOOt8YEa9rdFxBx4GN7pivOr0MUStltYjxfqySERYJdulJKpkInwc8GimPgThBa8Ya+JXTRF2RHiwybSunaolcnshQTW6M+uP3JtX+s9hVLcSsOns5EkZYSua+amy6/qrAexIfko7/W3W6NNYo7sGUf9no6zGLq0JHiw0wxDq7HOXjJDUGYeGlxEgHSw34OeRgBa/tIGna1siliIaZlDivaACHzj9KcFNgg==
   template:
     metadata:
       creationTimestamp: null

--- a/manifests/web-cluster/sdlc/helium/sealed-pyth-api-key.yaml
+++ b/manifests/web-cluster/sdlc/helium/sealed-pyth-api-key.yaml
@@ -1,0 +1,25 @@
+# TODO(pyth-upgrade/07): This is a PLACEHOLDER. The Pyth data-plan API key does
+# not exist yet. Once the key is procured, seal it against the SDLC web-cluster
+# sealed-secrets controller and replace encryptedData.secret below, e.g.:
+#
+#   echo -n "$PYTH_API_KEY" | kubeseal --raw \
+#     --namespace helium --name pyth-api-key \
+#     --controller-namespace kube-system --controller-name sealed-secrets \
+#     > sealed.txt
+#
+# Do NOT deploy this file with the placeholder value.
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: pyth-api-key
+  namespace: helium
+spec:
+  encryptedData:
+    secret: REPLACE_ME_WITH_SEALED_PYTH_API_KEY
+  template:
+    metadata:
+      creationTimestamp: null
+      name: pyth-api-key
+      namespace: helium

--- a/manifests/web-cluster/sdlc/helium/tuktuk-pyth-v2.yaml
+++ b/manifests/web-cluster/sdlc/helium/tuktuk-pyth-v2.yaml
@@ -20,7 +20,7 @@ spec:
         # TODO(pyth-upgrade/02): pin to the parameterized crank build that
         # supports the PYTH_* env vars below. 0.0.6 predates parameterization.
         - name: tuktuk-pyth-v2
-          image: public.ecr.aws/v0j6k5v6/tuktuk-pyth-service:0.0.7
+          image: public.ecr.aws/v0j6k5v6/tuktuk-pyth-service:0.0.8
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8081

--- a/manifests/web-cluster/sdlc/helium/tuktuk-pyth-v2.yaml
+++ b/manifests/web-cluster/sdlc/helium/tuktuk-pyth-v2.yaml
@@ -1,0 +1,163 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tuktuk-pyth-v2
+  name: tuktuk-pyth-v2
+  namespace: helium
+spec:
+  selector:
+    matchLabels:
+      app: tuktuk-pyth-v2
+  template:
+    metadata:
+      labels:
+        app: tuktuk-pyth-v2
+        security-group: public-rds-access
+    spec:
+      serviceAccountName: public-monitoring-rds-monitoring-user-access
+      containers:
+        # TODO(pyth-upgrade/02): pin to the parameterized crank build that
+        # supports the PYTH_* env vars below. 0.0.6 predates parameterization.
+        - name: tuktuk-pyth-v2
+          image: public.ecr.aws/v0j6k5v6/tuktuk-pyth-service:TODO-PARAMETERIZED-BUILD
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8081
+              name: http
+              protocol: TCP
+          env:
+            - name: SOLANA_URL
+              valueFrom:
+                secretKeyRef:
+                  name: helius-rpc-url
+                  key: secret
+            - name: PGHOST
+              value: monitoring-rds.cnigyps3bpgz.us-east-1.rds.amazonaws.com
+            - name: PGPORT
+              value: "5432"
+            - name: PGUSER
+              value: monitoring
+            - name: AWS_REGION
+              value: us-east-1
+            - name: PGDATABASE
+              value: monitoring
+            - name: PGSSLMODE
+              value: no-verify
+            - name: KEYPAIR_PATH
+              value: /usr/src/app/keys/keypair.json
+            - name: ORIGIN
+              value: https://tuktuk-pyth-v2.web.test-helium.com
+            - name: PYTH_HERMES_URL
+              value: https://pyth.dourolabs.app/hermes/
+            - name: PYTH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pyth-api-key
+                  key: secret
+            - name: PYTH_RECEIVER_PROGRAM_ID
+              value: rec2HHDDnjLfj4kE7VyEtFA1HPGQLK33259532cRyHp
+            - name: PYTH_PUSH_ORACLE_PROGRAM_ID
+              value: pyt2F414BA6dPttK6RddPZUdHfapoBN24GL5wbrPCou
+            - name: WORMHOLE_PROGRAM_ID
+              value: HDw2E7P8X1SkCyjvoGsfBGAVUutKcj874bXjHrpVYrVL
+
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: 8081
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 8081
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: tuktuk-pyth-keypair
+              mountPath: /usr/src/app/keys
+              readOnly: true
+          resources:
+            requests:
+              cpu: 200m
+              memory: 300Mi
+            limits:
+              cpu: 400m
+              memory: 400Mi
+      volumes:
+        - name: tuktuk-pyth-keypair
+          secret:
+            secretName: tuktuk-pyth-keypair
+            items:
+              - key: keypair.json
+                path: keypair.json
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tuktuk-pyth-v2
+  namespace: helium
+spec:
+  ports:
+    - port: 8081
+      protocol: TCP
+      targetPort: http
+  selector:
+    app: tuktuk-pyth-v2
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tuktuk-pyth-v2
+  namespace: helium
+  annotations:
+    nginx.ingress.kubernetes.io/limit-rps: "10"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "10"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: tuktuk-pyth-v2.web.test-helium.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tuktuk-pyth-v2
+                port:
+                  number: 8081
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: tuktuk-pyth-v2
+  namespace: helium
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: tuktuk-pyth-v2
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/manifests/web-cluster/sdlc/helium/tuktuk-pyth-v2.yaml
+++ b/manifests/web-cluster/sdlc/helium/tuktuk-pyth-v2.yaml
@@ -20,7 +20,7 @@ spec:
         # TODO(pyth-upgrade/02): pin to the parameterized crank build that
         # supports the PYTH_* env vars below. 0.0.6 predates parameterization.
         - name: tuktuk-pyth-v2
-          image: public.ecr.aws/v0j6k5v6/tuktuk-pyth-service:TODO-PARAMETERIZED-BUILD
+          image: public.ecr.aws/v0j6k5v6/tuktuk-pyth-service:0.0.7
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8081


### PR DESCRIPTION
Add tuktuk-pyth-v2 deployments (sdlc + prod) running tuktuk-pyth-service:0.0.8, which cranks the pro Pyth HNT feed (He5mh…) via Hermes Pro. Includes sealed Pyth API key secrets for both clusters. Runs alongside the existing v1 service — no changes to it; v1 stays up until v2 passes the 48h freshness gate (no publish gaps >600s, target July 22), then gets retired separately.